### PR TITLE
Now you have 3 options on how to highlight covered/uncovered lines.

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -9,6 +9,13 @@
         <![CDATA[
 <html>
 <h2>Changelog:</h2>
+
+<h3>v0.3.1</h3>
+<ul>
+    <li>Now you have 3 options on how to highlight covered/uncovered lines. Added new 'Error' checkbox in plugin settings.
+    </li>
+</ul>
+
 <h3>v0.3.0</h3>
 <ul>
 <li>Fixed issue #13 and #16. You may now toggle this highlight on and off. The plugin listens to the most recent

--- a/src/cc/takacs/php_codeverage_display/config/ConfigPanel.form
+++ b/src/cc/takacs/php_codeverage_display/config/ConfigPanel.form
@@ -91,7 +91,7 @@
           </hspacer>
         </children>
       </grid>
-      <grid id="fc678" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fc678" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -115,9 +115,19 @@
               <text value="Side"/>
             </properties>
           </component>
-          <hspacer id="aabc9">
+          <component id="506c" class="javax.swing.JCheckBox" binding="errorCheckBox">
             <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <horizontalAlignment value="2"/>
+              <horizontalTextPosition value="4"/>
+              <text value="Error"/>
+            </properties>
+          </component>
+          <hspacer id="951af">
+            <constraints>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
         </children>

--- a/src/cc/takacs/php_codeverage_display/config/ConfigPanel.java
+++ b/src/cc/takacs/php_codeverage_display/config/ConfigPanel.java
@@ -28,6 +28,9 @@ public class ConfigPanel {
     public JButton browseLocalDir;
     public JCheckBox dirTranslation;
     public JCheckBox useCoverageSuite;
+    // checkbox used to enable & disable error highlighting
+    // which usually looks like errors
+    public JCheckBox errorCheckBox;
 
     public ConfigPanel() {
         browseCloverXmlButton.addActionListener(
@@ -88,7 +91,7 @@ public class ConfigPanel {
         }
 
         public void actionPerformed(ActionEvent actionEvent) {
-            VirtualFile[] files = FileChooser.chooseFiles(panel, descriptor);
+            VirtualFile[] files = FileChooser.chooseFiles(descriptor, null, null);
 
             if (files.length > 0) {
                 field.setText(files[0].getPath());

--- a/src/cc/takacs/php_codeverage_display/config/ConfigValues.java
+++ b/src/cc/takacs/php_codeverage_display/config/ConfigValues.java
@@ -19,6 +19,7 @@ public class ConfigValues {
     public int uncoveredB = 0;
     public boolean highlightSides = false;
     public boolean highlightLines = true;
+    public boolean highlightErrors = false;
     public boolean directoryMapping = false;
     public String mapDirectoryFrom = "";
     public String mapDirectoryTo = "";
@@ -37,6 +38,7 @@ public class ConfigValues {
         uncoveredB = values.uncoveredB;
         highlightSides = values.highlightSides;
         highlightLines = values.highlightLines;
+        highlightErrors = values.highlightErrors;
         directoryMapping = values.directoryMapping;
         mapDirectoryFrom = values.mapDirectoryFrom;
         mapDirectoryTo = values.mapDirectoryTo;

--- a/src/cc/takacs/php_codeverage_display/config/PluginConfiguration.java
+++ b/src/cc/takacs/php_codeverage_display/config/PluginConfiguration.java
@@ -49,6 +49,7 @@ public class PluginConfiguration implements Configurable, PersistentStateCompone
                         !configValues.getUncoveredColor().equals(configPanel.uncoveredColor.getBackground()) ||
                         configValues.highlightLines != configPanel.lineCheckBox.isSelected() ||
                         configValues.highlightSides != configPanel.sideCheckBox.isSelected() ||
+                        configValues.highlightErrors != configPanel.errorCheckBox.isSelected() ||
                         configValues.useCoverageSuite != configPanel.useCoverageSuite.isSelected() ||
                         configValues.directoryMapping != configPanel.dirTranslation.isSelected() ||
                         !configValues.mapDirectoryFrom.equals(configPanel.localDir.getText()) ||
@@ -61,6 +62,7 @@ public class PluginConfiguration implements Configurable, PersistentStateCompone
         configValues.setUncoveredColor(configPanel.uncoveredColor.getBackground());
         configValues.highlightLines = configPanel.lineCheckBox.isSelected();
         configValues.highlightSides = configPanel.sideCheckBox.isSelected();
+        configValues.highlightErrors = configPanel.errorCheckBox.isSelected();
         configValues.useCoverageSuite = configPanel.useCoverageSuite.isSelected();
         configValues.directoryMapping = configPanel.dirTranslation.isSelected();
         configValues.mapDirectoryFrom = configPanel.localDir.getText();
@@ -76,6 +78,7 @@ public class PluginConfiguration implements Configurable, PersistentStateCompone
         configPanel.uncoveredColor.setBackground(configValues.getUncoveredColor());
         configPanel.sideCheckBox.setSelected(configValues.highlightSides);
         configPanel.lineCheckBox.setSelected(configValues.highlightLines);
+        configPanel.errorCheckBox.setSelected(configValues.highlightErrors);
         configPanel.useCoverageSuite.setSelected(configValues.useCoverageSuite);
         configPanel.dirTranslation.setSelected(configValues.directoryMapping);
         configPanel.localDir.setText(configValues.mapDirectoryFrom);

--- a/src/cc/takacs/php_codeverage_display/display/CoverageHighlighter.java
+++ b/src/cc/takacs/php_codeverage_display/display/CoverageHighlighter.java
@@ -45,7 +45,9 @@ public class CoverageHighlighter {
                 sideHighlighter.highlight(highlighter, attributes, color, executed);
             }
 
-            errorStripeMarkHighlighter.highlight(highlighter, attributes, color, executed);
+            if (configValues.highlightErrors) {
+                errorStripeMarkHighlighter.highlight(highlighter, attributes, color, executed);
+            }
 
             highlights.add(highlighter);
         }


### PR DESCRIPTION
Resolves issue #20

Added new 'Error' checkbox in plugin settings.
